### PR TITLE
Manage game start countdown and button

### DIFF
--- a/backend/socket/socketHandler.js
+++ b/backend/socket/socketHandler.js
@@ -337,8 +337,26 @@ module.exports = (io) => {
         const room = await Room.findById(roomId);
         if (!room) return;
 
+        // Find the player and toggle their ready status
+        const playerIndex = room.players.findIndex(p => p.user.toString() === socket.userId.toString());
+        if (playerIndex === -1) {
+          socket.emit('error', { message: 'Player not found in room' });
+          return;
+        }
+
+        // Toggle the ready status
+        room.players[playerIndex].isReady = !room.players[playerIndex].isReady;
+        await room.save();
+
+        // Emit the player ready toggled event to all players in the room
+        io.to(roomId).emit('player-ready-toggled', {
+          userId: socket.userId,
+          isReady: room.players[playerIndex].isReady
+        });
+
+        // Check if all active players are ready
         const activePlayers = room.players.filter(p => !p.isSpectator);
-            if (activePlayers.length > 0 && activePlayers.every(p => p.isReady)) {
+        if (activePlayers.length >= 2 && activePlayers.every(p => p.isReady)) {
           // Start 30-second countdown instead of immediately starting game
           io.to(roomId).emit('countdown-update', { countdown: 30 });
           let countdown = 30;
@@ -352,9 +370,9 @@ module.exports = (io) => {
             }
           }, 1000);
           manualStartTimers.set(roomId, countdownInterval);
-            } else {
-              // If not all ready, cancel any existing countdown
-              io.to(roomId).emit('countdown-cancelled');
+        } else {
+          // If not all ready, cancel any existing countdown
+          io.to(roomId).emit('countdown-cancelled');
           if (manualStartTimers.has(roomId)) {
             clearInterval(manualStartTimers.get(roomId));
             manualStartTimers.delete(roomId);

--- a/frontend/src/components/Room.js
+++ b/frontend/src/components/Room.js
@@ -319,7 +319,6 @@ const Room = () => {
   const [room, setRoom] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [isReady, setIsReady] = useState(false);
   const [hasJoined, setHasJoined] = useState(false);
   const [socketReady, setSocketReady] = useState(false);
   const [countdown, setCountdown] = useState(null);
@@ -455,8 +454,7 @@ const Room = () => {
 
   const handleToggleReady = useCallback(() => {
     toggleReady(roomId);
-    setIsReady(!isReady);
-  }, [roomId, toggleReady, isReady]);
+  }, [roomId, toggleReady]);
 
   const handleStartGame = useCallback(() => {
     navigate(`/game/${roomId}`);
@@ -513,6 +511,13 @@ const Room = () => {
   const isHost = hostName === user.username;
   const allReady = room.players.every(p => p.isReady);
   const canStart = isHost && allReady && room.players.length >= 2;
+  
+  // Get current user's ready status from room data
+  const currentPlayer = room.players.find(p => {
+    const playerName = typeof p.user === 'string' ? p.user : p.user?.username;
+    return playerName === user.username;
+  });
+  const isReady = currentPlayer?.isReady || false;
 
   return (
     <div>


### PR DESCRIPTION
Enable game countdown and immediate start by synchronizing player ready states between frontend and backend.

The previous implementation had a bug where the backend's `toggle-ready` socket handler did not persist the player's ready status to the database, preventing the countdown from initiating correctly when both players were ready. This PR fixes the backend to update the ready status and refactors the frontend to derive the ready state directly from the room data, ensuring consistent behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6656da8-6ccb-4de0-9b00-585804285d36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6656da8-6ccb-4de0-9b00-585804285d36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

